### PR TITLE
Added a setting to slow down character when moving against a wall

### DIFF
--- a/Assets/_Standard Assets/Characters/Scripts/Physics/Editor/OpenCharacterControllerEditor.cs
+++ b/Assets/_Standard Assets/Characters/Scripts/Physics/Editor/OpenCharacterControllerEditor.cs
@@ -1,5 +1,7 @@
-﻿using StandardAssets.Characters.Physics;
+﻿using System;
+using StandardAssets.Characters.Physics;
 using UnityEditor;
+using UnityEngine;
 
 namespace StandardAssets.Characters.Editor
 {
@@ -9,29 +11,53 @@ namespace StandardAssets.Characters.Editor
 	[CustomEditor(typeof(OpenCharacterController))]
 	public class OpenCharacterControllerEditor : UnityEditor.Editor
 	{
+		const string k_MinSlowAgainstWallsAngle = "m_MinSlowAgainstWallsAngle";
+
 		// List of names of advanced fields
-		readonly string[] m_AdvancedFields = 
+		readonly string[] m_AdvancedFields =
 		{
-			"m_SkinWidth", 
-			"m_MinMoveDistance", 
+			"m_SkinWidth",
+			"m_MinMoveDistance",
 			"m_IsLocalHuman",
-			"m_SlideAlongCeiling", 
+			"m_SlideAlongCeiling",
 			"m_TriggerQuery"
 		};
 
 		// Tracks the whether the advanced foldout is open/collapse
 		bool m_AdvancedFoldOut;
-		
+
 
 		/// <summary>
 		/// Renders advanced fields
 		/// </summary>
 		public override void OnInspectorGUI()
 		{
-			DrawPropertiesExcluding(serializedObject, m_AdvancedFields);
+			DrawPropertiesExcluding(serializedObject, GetExclusions());
 
 			EditorGUILayout.Space();
 			serializedObject.DrawFieldsUnderFoldout("Advanced", m_AdvancedFields, ref m_AdvancedFoldOut);
+
+			if (GUI.changed)
+			{
+				serializedObject.ApplyModifiedProperties();
+			}
+		}
+
+		string[] GetExclusions()
+		{
+			var controller = (OpenCharacterController) target;
+
+			if (!controller.slowAgainstWalls)
+			{
+				var array = new string[m_AdvancedFields.Length + 1];
+
+				Array.Copy(m_AdvancedFields, array, m_AdvancedFields.Length);
+				array[m_AdvancedFields.Length] = k_MinSlowAgainstWallsAngle;
+
+				return array;
+			}
+
+			return m_AdvancedFields;
 		}
 	}
 }

--- a/Assets/_Standard Assets/Characters/Scripts/Physics/OpenCharacterController.cs
+++ b/Assets/_Standard Assets/Characters/Scripts/Physics/OpenCharacterController.cs
@@ -547,6 +547,9 @@ namespace StandardAssets.Characters.Physics
 		/// </summary>
 		public float defaultHeight { get; private set; }
 		
+		/// <summary>
+		/// Is the character being slowed down by walls?
+		/// </summary>
 		public bool slowAgainstWalls { get { return m_SlowAgainstWalls; } }
 
 		/// <summary>
@@ -573,8 +576,8 @@ namespace StandardAssets.Characters.Physics
 			InitCapsuleColliderAndRigidbody();
 
 			SetRootToOffset();
-			UpdateSlowAgainstWalls();
 			
+			m_InvRescaleFactor = 1 / Mathf.Cos(m_MinSlowAgainstWallsAngle * Mathf.Deg2Rad);
 			m_SlopeMovementOffset =  m_StepOffset / Mathf.Tan(m_SlopeLimit * Mathf.Deg2Rad);
 		}
 
@@ -599,7 +602,8 @@ namespace StandardAssets.Characters.Physics
 			ValidateCapsule(false, ref position);
 			transform.position = position;
 			SetRootToOffset();
-			UpdateSlowAgainstWalls();
+			
+			m_InvRescaleFactor = 1 / Mathf.Cos(m_MinSlowAgainstWallsAngle * Mathf.Deg2Rad);
 		}
 
 		// Draws the debug Gizmos
@@ -2194,9 +2198,5 @@ namespace StandardAssets.Characters.Physics
 		}
 
 		// Update values that are used for computing slow down against walls.
-		void UpdateSlowAgainstWalls()
-		{
-			m_InvRescaleFactor = 1 / Mathf.Cos(m_MinSlowAgainstWallsAngle * Mathf.Deg2Rad);
-		}
 	}
 }

--- a/Assets/_Standard Assets/Characters/Scripts/Physics/OpenCharacterController.cs
+++ b/Assets/_Standard Assets/Characters/Scripts/Physics/OpenCharacterController.cs
@@ -1849,13 +1849,7 @@ namespace StandardAssets.Characters.Physics
 				project.Normalize();
 
 				// Slide along the obstacle
-				var isWallSlowingDown = m_SlowAgainstWalls;
-				
-				if (isWallSlowingDown && m_MinSlowAgainstWallsAngle >= 90.0f)
-				{
-					// If the user has set the minimum angle to slow down to 90.0f, we disable the functionality.
-					isWallSlowingDown = false;
-				}
+				var isWallSlowingDown = m_SlowAgainstWalls && m_MinSlowAgainstWallsAngle < 90.0f;
 
 				if (isWallSlowingDown)
 				{

--- a/Assets/_Standard Assets/Characters/Scripts/Physics/OpenCharacterController.cs
+++ b/Assets/_Standard Assets/Characters/Scripts/Physics/OpenCharacterController.cs
@@ -548,7 +548,7 @@ namespace StandardAssets.Characters.Physics
 		public float defaultHeight { get; private set; }
 		
 		/// <summary>
-		/// Is the character being slowed down by walls?
+		/// Is the character able to be slowed down by walls?
 		/// </summary>
 		public bool slowAgainstWalls { get { return m_SlowAgainstWalls; } }
 

--- a/Assets/_Standard Assets/Characters/Scripts/Physics/OpenCharacterController.cs
+++ b/Assets/_Standard Assets/Characters/Scripts/Physics/OpenCharacterController.cs
@@ -2196,7 +2196,5 @@ namespace StandardAssets.Characters.Physics
 				m_PlayerRootTransform.localPosition = m_RootTransformOffset;
 			}
 		}
-
-		// Update values that are used for computing slow down against walls.
 	}
 }


### PR DESCRIPTION
Based on this feedback from the forum post:
https://forum.unity.com/threads/new-standard-asset-characters-third-person.526612/page-3#post-4045138
I added an option to slow down the character when moving against a wall, by the angle.

---

Variables added in `OpenCharacterController.css`:  

`m_OnWallsKeepVelocity` -> If this option is enabled, the player will not be slowed down when against a wall (as before). If it's disabled, the character will be slowed down.  

`m_OnWallsMaxAngle` -> The maximal angle before the character will not be slowed down:
- If it's at 0°, any angle will be able to slow down the character. 
- If it's at 90°, it will act as if this option was disabled. 
- It's by default at 10° so characters will keep a perfect velocity if it's just touching a bit a wall. 

If some users still want the current behavior, they will just need to enable `m_OnWallsKeepVelocity`.

---

This is my first pull request, so if I missed something in my PR, I'm sorry.
(I think it would be also possible to reduce the code size of this PR)