### PR TITLE
add: package manager support

### DIFF
--- a/Assets/_Standard Assets/Characters/Scripts/Editor/Unity.StandardAssetsCharacters.Editor.asmdef
+++ b/Assets/_Standard Assets/Characters/Scripts/Editor/Unity.StandardAssetsCharacters.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "Unity.StandardAssetsCharacters.Editor",
+    "rootNamespace": "",
+    "references": [
+        "Unity.StandardAssetsCharacters"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/_Standard Assets/Characters/Scripts/Editor/Unity.StandardAssetsCharacters.Editor.asmdef.meta
+++ b/Assets/_Standard Assets/Characters/Scripts/Editor/Unity.StandardAssetsCharacters.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3512493c55fbe9a46acfa2303874bc4e
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Standard Assets/Characters/Scripts/Physics/Editor/Unity.StandardAssetsCharacters.Physics.Editor.asmref
+++ b/Assets/_Standard Assets/Characters/Scripts/Physics/Editor/Unity.StandardAssetsCharacters.Physics.Editor.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "Unity.StandardAssetsCharacters.Editor"
+}

--- a/Assets/_Standard Assets/Characters/Scripts/Physics/Editor/Unity.StandardAssetsCharacters.Physics.Editor.asmref.meta
+++ b/Assets/_Standard Assets/Characters/Scripts/Physics/Editor/Unity.StandardAssetsCharacters.Physics.Editor.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 99b4eb09dc53066458479ad276ad5a19
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Standard Assets/Characters/Scripts/ThirdPerson/AnimatorBehaviours/Editor/Unity.StandardAssetsCharacters.ThirdPerson.Editor.asmref
+++ b/Assets/_Standard Assets/Characters/Scripts/ThirdPerson/AnimatorBehaviours/Editor/Unity.StandardAssetsCharacters.ThirdPerson.Editor.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "Unity.StandardAssetsCharacters.Editor"
+}

--- a/Assets/_Standard Assets/Characters/Scripts/ThirdPerson/AnimatorBehaviours/Editor/Unity.StandardAssetsCharacters.ThirdPerson.Editor.asmref.meta
+++ b/Assets/_Standard Assets/Characters/Scripts/ThirdPerson/AnimatorBehaviours/Editor/Unity.StandardAssetsCharacters.ThirdPerson.Editor.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ac16b7b15eed60f47a7a6943ba24f2e3
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Standard Assets/Unity.StandardAssetsCharacters.asmdef
+++ b/Assets/_Standard Assets/Unity.StandardAssetsCharacters.asmdef
@@ -1,0 +1,17 @@
+{
+    "name": "Unity.StandardAssetsCharacters",
+    "rootNamespace": "",
+    "references": [
+        "Unity.InputSystem",
+        "Cinemachine"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/_Standard Assets/Unity.StandardAssetsCharacters.asmdef.meta
+++ b/Assets/_Standard Assets/Unity.StandardAssetsCharacters.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 74cbbd511068a0b41a0c08936245fa15
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/package.json
+++ b/Assets/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "com.unity.standard-assets-characters",
+  "version": "1.0.0-beta+build.1677",
+  "displayName": "Standard Assets Characters",
+  "description": "This repository contains the new Standard Assets Character Controller Package, consisting of both code to drive a more advanced version of First and Third Person Characters than the old Standard Assets Character, as well as a demo scene and setup for Character prototyping purposes and example setup of First and Third Person Characters.",
+  "unity": "2019.3",
+  "unityRelease": "0f1",
+  "documentationUrl": "https://github.com/Unity-Technologies/Standard-Assets-Characters.git",
+  "dependencies": {
+    "com.unity.cinemachine": "2.4.0-preview.8",
+    "com.unity.inputsystem": "1.0.0-preview.3",
+    "com.unity.postprocessing": "2.2.2",
+    "com.unity.probuilder": "4.1.2"
+  }
+}

--- a/Assets/package.json.meta
+++ b/Assets/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 36e76260ee75f734abc400204efd6df4
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Use UPM to easily load/unload assets without having to import a large number of unnecessary sample files into project folder for testing/prototyping purpose.

Tested with Unity 2021.3
Install Git URL: https://github.com/sator-imaging/Standard-Assets-Characters.git?path=Assets
